### PR TITLE
Update xchat.rst

### DIFF
--- a/docs/xchat.rst
+++ b/docs/xchat.rst
@@ -24,7 +24,7 @@ For Fedora:
 
 For Ubuntu:
 ::
-    # apt-get install xchat
+    # apt-get install hexchat
 
 For windows please download hexchat from their `site <https://hexchat.github.io/>`_.
 


### PR DESCRIPTION
xchat is no longer maintained for ubuntu. The previous instruction to install xchat doesn't work. Instead added instruction to install hexchat.